### PR TITLE
[TBR] Use primary

### DIFF
--- a/lib/monmo-repl.js
+++ b/lib/monmo-repl.js
@@ -217,7 +217,8 @@ function opQuery(){
     .sort({$natural:1})
     .addOption(DBQuery.Option.tailable)
     .addOption(DBQuery.Option.noTimeout)
-    .addOption(DBQuery.Option.awaitdata);
+    .addOption(DBQuery.Option.awaitdata)
+    .addOption(DBQuery.Option.oplogReplay);
 }
 
 function replLoop(){

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -40,7 +40,10 @@ ReplSet.prototype = {
         if ( member.state === 1 || member.state === 2 ) {
           try {
             this.monmo_db = connect(member.name + '/' + this.info.basedb);
-            this.monmo_db.setSlaveOk(true);
+            if (! this.monmo_db.isMaster().ismaster) {
+              logger(LOGLV.WARN, 'Skipping. Hit non-primary member:' + host);
+              continue;
+            }
             this.primary = this.monmo_db.getMongo();
             this.monmo_db.getSiblingDB(this.info.auth.db).auth(this.info.auth.user,this.info.auth.passwd);
             break;


### PR DESCRIPTION
Unfortunately, previous version doesn't work well if there's a delaying replica member at the very beginning of `replSetStatus.members`.
In this PR, it is enforced to connect only primary node.